### PR TITLE
Allow to pass value from top

### DIFF
--- a/src/connectField.js
+++ b/src/connectField.js
@@ -114,13 +114,14 @@ export default function connectField(fieldName, defaultProps = {}, customValidat
 
         const defaultProps = this._resolveDefaultProps();
         const fieldProps = this.getFieldProps();
+        const value = undefined !== rest.value ? rest.value : (fieldProps.value || '');
 
         return (
           <FieldComponent
             {...rest}
             {...defaultProps}
             {...fieldProps}
-            value={fieldProps.value || ''}
+            value={value}
             error={error && this.msg(`errors.${error}`, error) || error}
             hint={hint || defaultProps.hint || this.msg(`${fieldName}.hint`)}
             label={label || defaultProps.label || this.msg(`${fieldName}.label`)}

--- a/test/connectField.spec.js
+++ b/test/connectField.spec.js
@@ -116,6 +116,20 @@ describe('connectField()', () => {
       );
     });
 
+    it('Checkbox should pass value prop set on connected field without overriding it', () => {
+      assert.equal(
+        createStubs({ value: true }).checkBox.props.value,
+        true
+      );
+    });
+
+    it('Text Field should pass value prop set on connected field without overriding it', () => {
+      assert.equal(
+        createStubs({ value: 'unoverridable' }).textField.props.value,
+        'unoverridable'
+      );
+    });
+
     it('Text Field decorated with translate (msg given) should have hint translated', () => {
       assert.equal(
         createStubs({ msg: (key) => `Translated ${key[0]}` }).textField.props.hint,


### PR DESCRIPTION
Useful e.g. for check/uncheck all checkbox. Value can be combined from other values and passed directly to check-all checkbox. IMHO it is better to move `{...rest}` props below others,  but I'm not sure if this behaviour is wanted (?)