### PR TITLE
Add hasValues prop to connected submit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onion-form",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "onion-form",
   "typings": "index",
   "main": "lib/index.js",

--- a/src/connectSubmit.js
+++ b/src/connectSubmit.js
@@ -1,6 +1,7 @@
 import createContextExtractor from './createContextExtractor';
 import hasApiErrors from './hasApiErrors';
 import hasErrors from './hasErrors';
+import hasValues from './hasValues';
 import { connect } from 'react-redux';
 
 export default function connectSubmit(Submit) {
@@ -9,9 +10,11 @@ export default function connectSubmit(Submit) {
       (state, { disabled, onionFormName }) => {
         const anyValidationErrors = hasErrors(state, onionFormName);
         const anyApiErrors = hasApiErrors(state, onionFormName);
+        const anyValues = hasValues(state, onionFormName);
         return {
           disabled: anyValidationErrors || !!disabled,
-          hasErrors: anyValidationErrors || anyApiErrors
+          hasErrors: anyValidationErrors || anyApiErrors,
+          hasValues: anyValues
         };
       },
       (state, { onClick, onionOnSubmit }) => ({

--- a/src/hasValues.js
+++ b/src/hasValues.js
@@ -1,0 +1,7 @@
+import extractPropertyFromState from './extractPropertyFromState';
+
+export default function hasValues(state, name) {
+  const errors = Object.values(extractPropertyFromState(state, name, 'value'));
+
+  return (errors.filter(v => v !== undefined && v !== null).length > 0);
+}

--- a/test/hasValues.spec.js
+++ b/test/hasValues.spec.js
@@ -1,0 +1,33 @@
+import hasValues from '../src/hasValues';
+import { assert } from 'chai';
+import { fromJS } from 'immutable';
+
+describe('hasValues()', () => {
+  const state = {
+    onionForm: fromJS({
+      fields: {
+        WithValue: {
+          foo: { value: 'required' },
+          bar: { }
+        },
+        NoValue: {
+          foo: { value: null },
+          bar: { }
+        },
+        NoFields: {}
+      }
+    })
+  };
+
+  it('form with at least one field with value', () => {
+    assert.isTrue(hasValues(state, 'WithValue'));
+  });
+
+  it('form with fields with null value', () => {
+    assert.isFalse(hasValues(state, 'NoValue'));
+  });
+
+  it('form with no fields', () => {
+    assert.isFalse(hasValues(state, 'NoFields'));
+  });
+});


### PR DESCRIPTION
To be able to disable the submit button until all values are set/valid.

```js
const SubmitButton = ({ children, hasValues, hasErrors}) => (
  <Button
    arrows
    disabled={!hasValues || hasErrors}
    kind="blue"
    fullWidth
    textAlign="right"
  >
    {children}
  </Button>
);
```