### PR TITLE
Seamless-Immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,9 @@
     "sinon-chai": "^2.8.0",
     "tmp": "0.0.28"
   },
-  "dependencies": {},
+  "dependencies": {
+    "seamless-immutable": "^7.1.2"
+  },
   "peerDependencies": {
     "immutable": ">=3",
     "react": ">=0.14.2 || >=15.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "eslint-plugin-standard": "^1.3.1",
     "fetch-mock": "^5.1.5",
     "flow-bin": "^0.46.0",
-    "immutable": "^3.8.1",
     "istanbul": "1.0.0-alpha.2",
     "jsdoc": "git+https://github.com/jsdoc3/jsdoc.git",
     "jsdom": "^9.4.1",
@@ -88,7 +87,6 @@
     "seamless-immutable": "^7.1.2"
   },
   "peerDependencies": {
-    "immutable": ">=3",
     "react": ">=0.14.2 || >=15.0.0",
     "react-redux": ">=3",
     "redux": ">=3"

--- a/src/Form.react.js
+++ b/src/Form.react.js
@@ -1,8 +1,8 @@
+import Immutable from 'seamless-immutable';
 import extractPropertyFromState from './extractPropertyFromState';
 import hasErrors from './hasErrors';
 import React, { Component, PropTypes as RPT } from 'react';
 import validateField from './validateField';
-import { Map } from 'immutable';
 import { clearFormProperty, setMultipleFields, registerField } from './actions';
 
 export default class Form extends Component {
@@ -76,7 +76,7 @@ export default class Form extends Component {
       this.fields[fieldName] = field;
 
       // Try if field has already data in store
-      if (Map.isMap(getState().onionForm.getIn(['fields', name, fieldName]))) {
+      if (Immutable.isImmutable(getState().onionForm.getIn(['fields', name, fieldName]))) {
         // Lets try to validate it!
         const errors = this._getValidationErrors(this._allFieldNames());
         if (!this.hasAnyError(errors)) {

--- a/src/connectField.js
+++ b/src/connectField.js
@@ -102,7 +102,7 @@ export default function connectField(fieldName, defaultProps = {}, customValidat
 
       getFieldProps(props = this.props) {
         const { field } = props;
-        return field ? field.toJS() : {};
+        return field || {};
       }
 
       validations() {

--- a/src/extractPropertyFromFields.js
+++ b/src/extractPropertyFromFields.js
@@ -1,8 +1,10 @@
+import { reduceObject } from './helpers';
+
 export default function extractPropertyFromFields(fields, property) {
-  return (fields || []).reduce(
+  return reduceObject(fields || {},
     (acc, properties, field) => ({
       ...acc,
-      [field]: properties && properties.get(property) || null
+      [field]: properties && properties[property] || null
     }),
     {}
   );

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,45 @@
+/* @flow */
+import Immutable from 'seamless-immutable';
+
+type ValueMapper = (field: any, index: number) => any;
+
+export function mapValues(structure: Object, mapper: ValueMapper): Object {
+  const defaultObject: Object = Immutable.isImmutable(structure) ? Immutable({}) : {};
+  const oldValues: any = Object.values(structure);
+  const keys: Array<string> = Object.keys(structure);
+  const newValues: any = oldValues.map(mapper);
+
+  return newValues.reduce((acc: Object, value: any, index: number): Object => {
+    const shape: Object = {
+      ...acc,
+      [keys[index]]: value
+    };
+    return Immutable.isImmutable(acc)
+      ? Immutable(shape) : shape;
+  }, defaultObject);
+}
+
+type KeysMapper = (key: string, index: number) => string;
+
+export function mapKeys(structure: Object, mapper: KeysMapper): Object {
+  const defaultObject: Object = Immutable.isImmutable(structure) ? Immutable({}) : {};
+  const oldKeys: Array<string> = Object.keys(structure);
+  const newKeys: Array<string> = oldKeys.map(mapper);
+  return newKeys.reduce((acc: Object, key: string, index: number) => {
+    const shape: Object = {
+      ...acc,
+      [key]: structure[oldKeys[index]]
+    };
+    return Immutable.isImmutable(acc)
+      ? Immutable(shape) : shape;
+  }, defaultObject);
+}
+
+type Reducer = (acc: Object, value: any, key: string, index:number, iter: Object) => Object;
+
+export function reduceObject(structure: Object, reducer: Reducer, accumulator: any): any {
+  const keys: Array<string> = Object.keys(structure);
+  const values: Array<any> = Object.values(structure);
+  return values.reduce((acc: Object, value: any, index: number) =>
+    reducer(acc, value, keys[index], index, structure), accumulator);
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -39,7 +39,7 @@ type Reducer = (acc: Object, value: any, key: string, index:number, iter: Object
 
 export function reduceObject(structure: Object, reducer: Reducer, accumulator: any): any {
   const keys: Array<string> = Object.keys(structure);
-  const values: Array<any> = Object.values(structure);
+  const values: Array<any> = keys.map(key => structure[key]);
   return values.reduce((acc: Object, value: any, index: number) =>
     reducer(acc, value, keys[index], index, structure), accumulator);
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,6 +37,12 @@ export function mapKeys(structure: Object, mapper: KeysMapper): Object {
 
 type Reducer = (acc: Object, value: any, key: string, index:number, iter: Object) => Object;
 
+/*
+  This is convenience method, with the same API as reduce method used on Immutable Maps.
+  In order to somehow blend in seamless immutable API, this helper behaves as a static
+  method. For a first time reader it's easier to lookup import of this fn, than search
+  for mysterious extended prototype.
+*/
 export function reduceObject(structure: Object, reducer: Reducer, accumulator: any): any {
   const keys: Array<string> = Object.keys(structure);
   const values: Array<any> = keys.map(key => structure[key]);

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ export Button from './Button.react';
 
 // Redux
 export * as actions from './actions';
-export reducer, { InitialState } from './reducer';
+export reducer, { initialState } from './reducer';
 
 // Decorators
 export connectField from './connectField';

--- a/test/extractPropertyFromFields.spec.js
+++ b/test/extractPropertyFromFields.spec.js
@@ -1,12 +1,11 @@
 import extractPropertyFromFields from '../src/extractPropertyFromFields';
 import { assert } from 'chai';
-import { fromJS } from 'immutable';
 
 describe('extractPropertyFromFields()', () => {
-  const fields = fromJS({
+  const fields = {
     foo: { value: 'Bar', missingProp: true },
     bar: { value: 'Foo', }
-  });
+  };
 
   it('extract property from null fields', () => {
     assert.deepEqual(

--- a/test/extractPropertyFromState.spec.js
+++ b/test/extractPropertyFromState.spec.js
@@ -1,10 +1,10 @@
 import extractPropertyFromState from '../src/extractPropertyFromState';
+import Immutable from 'seamless-immutable';
 import { assert } from 'chai';
-import { fromJS } from 'immutable';
 
 describe('extractPropertyFromState()', () => {
   const state = {
-    onionForm: fromJS({
+    onionForm: Immutable({
       fields: {
         Form1: {
           foo: { value: 'Bar', missingProp: true },

--- a/test/hasApiErrors.spec.js
+++ b/test/hasApiErrors.spec.js
@@ -1,10 +1,10 @@
 import hasApiErrors from '../src/hasApiErrors';
 import { assert } from 'chai';
-import { fromJS } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 describe('hasApiErrors()', () => {
   const state = {
-    onionForm: fromJS({
+    onionForm: Immutable({
       fields: {
         WithError: {
           foo: { apiError: 'required' },

--- a/test/hasErrors.spec.js
+++ b/test/hasErrors.spec.js
@@ -1,10 +1,10 @@
 import hasErrors from '../src/hasErrors';
 import { assert } from 'chai';
-import { fromJS } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 describe('hasErrors()', () => {
   const state = {
-    onionForm: fromJS({
+    onionForm: Immutable({
       fields: {
         WithError: {
           foo: { error: 'required' },

--- a/test/hasValues.spec.js
+++ b/test/hasValues.spec.js
@@ -1,10 +1,10 @@
 import hasValues from '../src/hasValues';
 import { assert } from 'chai';
-import { fromJS } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 describe('hasValues()', () => {
   const state = {
-    onionForm: fromJS({
+    onionForm: Immutable({
       fields: {
         WithValue: {
           foo: { value: 'required' },

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -1,0 +1,37 @@
+import { assert } from 'chai';
+import {
+  mapValues,
+  mapKeys,
+  reduceObject
+} from '../src/helpers';
+
+describe('Helpers', () => {
+  const testObject = {
+    key1: 'prop1',
+    key2: 'prop2'
+  };
+  it('Maps over object values', () => {
+    const mapped = mapValues(testObject, value => `${value}-mapped`);
+    const expected = {
+      key1: 'prop1-mapped',
+      key2: 'prop2-mapped'
+    };
+    assert.deepEqual(mapped, expected);
+  });
+
+  it('Maps over object keys', () => {
+    const mapped = mapKeys(testObject, key => `${key}-mapped`);
+    const expected = {
+      'key1-mapped': 'prop1',
+      'key2-mapped': 'prop2'
+    };
+    assert.deepEqual(mapped, expected);
+  });
+
+  it('Reduces object', () => {
+    const reduced = reduceObject(testObject, (acc, value, key) => [...acc, [key, value]], []);
+    const expected = [['key1', 'prop1'], ['key2', 'prop2']];
+
+    assert.deepEqual(reduced, expected);
+  });
+});

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -1,9 +1,7 @@
 import * as actions from '../src/actions';
-import reducer, { InitialState, deafultFieldProperties } from '../src/reducer';
+import reducer, { initialState, deafultFieldProperties } from '../src/reducer';
 import { assert } from 'chai';
-import { Map } from 'immutable';
-
-const initialState = new InitialState;
+import Immutable from 'seamless-immutable';
 
 describe('reducer()', () => {
   it('should initialize state', () => {
@@ -13,27 +11,27 @@ describe('reducer()', () => {
     );
   });
 
-  it('should revive state with fields as map', () => {
+  it('should revive state with fields as Immutable', () => {
     const state = reducer({ fields: { registration: { firstName: { value: 'Foo', blured: true } } } }, {});
-    const value = state.get('fields');
-    assert(Map.isMap(value), `Should be map but is ${typeof value}`);
+    const value = state.fields;
+    assert(Immutable.isImmutable(value), 'Should be Immutable');
   });
 
-  it('should revive state with form as map', () => {
+  it('should revive state with form as Immutable', () => {
     const state = reducer({ fields: { registration: { firstName: { value: 'Foo', blured: true } } } }, {});
     const value = state.getIn(['fields', 'registration']);
-    assert(Map.isMap(value), `Should be map but is ${typeof value}`);
-    assert.deepEqual(Object.keys(state.get('fields').toJS()), ['registration']);
+    assert(Immutable.isImmutable(value), 'Should be Immutable');
+    assert.deepEqual(Object.keys(state.fields), ['registration']);
   });
 
   it('should revive state with form and field', () => {
     const state = reducer({ fields: { registration: { firstName: { value: 'Foo', blured: true } } } }, {});
-    assert.deepEqual(Object.keys(state.getIn(['fields', 'registration']).toJS()), ['firstName']);
+    assert.deepEqual(Object.keys(state.getIn(['fields', 'registration'])), ['firstName']);
   });
 
   it('should revive and field should have default fields', () => {
     const state = reducer({ fields: { registration: { firstName: { value: 'Foo', blured: true } } } }, {});
-    assert.deepEqual(state.getIn(['fields', 'registration', 'firstName']).toJS(), {
+    assert.deepEqual(state.getIn(['fields', 'registration', 'firstName']), {
       apiError: null,
       value: 'Foo',
       error: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,19 +685,12 @@ babel-plugin-transform-export-extensions@^6.3.13:
     babel-plugin-syntax-export-extensions "^6.8.0"
     babel-runtime "^6.0.0"
 
-babel-plugin-transform-flow-strip-types@^6.22.0:
+babel-plugin-transform-flow-strip-types@^6.22.0, babel-plugin-transform-flow-strip-types@^6.3.13:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
-
-babel-plugin-transform-flow-strip-types@^6.3.13:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.18.0.tgz#4d3e642158661e9b40db457c004a30817fa32592"
-  dependencies:
-    babel-plugin-syntax-flow "^6.18.0"
-    babel-runtime "^6.0.0"
 
 babel-plugin-transform-function-bind@^6.3.13:
   version "6.8.0"
@@ -869,19 +862,19 @@ babel-register@^6.18.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.2.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
-  version "6.11.6"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.9.5"
-
-babel-runtime@^6.22.0:
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.2.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+  version "6.11.6"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.9.5"
 
 babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.3.0, babel-template@^6.8.0:
   version "6.16.0"
@@ -3186,6 +3179,10 @@ samsam@1.1.2, samsam@~1.1:
 sax@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
+seamless-immutable@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.2.tgz#c87a1eba6767a32455311d76600ac5eddeafbb69"
 
 semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
Switched from regular `immutable` to `seamless-immutable`, because it's more hip, and also it makes typing with flow much easier.

Changes...

- Created helpers like `reduceObject` as alternative to stuff like mapping Immutable Map.
- Changed various places, where `toJS`, `isMap` etc. was used
- Tests changed, so it works with seamless-immutable