### PR TITLE
Set otherValues parameter in validateField as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,7 +108,7 @@ export function extractPropertyFromState(state: any, formName: any, property: st
 
 export function reducer(state: InitialState, action: Action): InitialState;
 
-export function validateField(value: any, validations: Validation[], otherValues: Values): any;
+export function validateField(value: any, validations: Validation[], otherValues?: Values): any;
 
 export namespace actions {
     const CLEAR_ONION_FORM: string;


### PR DESCRIPTION
I think that otherValues param isn't needed for field validation. Am i wrong? It follows from validateField.spec.js test file.